### PR TITLE
Fix java jdk depends on

### DIFF
--- a/Formula/caver-java.rb
+++ b/Formula/caver-java.rb
@@ -4,7 +4,7 @@ class CaverJava < Formula
   url "https://github.com/klaytn/caver-java/releases/download/v1.3.1/caver-java.zip"
 
   sha256 "7993fb566c69fc530e0c4090bfd807293b4823fd94347e88f2d3d1ff3353ff70"
-  depends_on :java => "1.8+"
+  depends_on :java => "openjdk@8"
 
   def install
     prefix.install "lib"

--- a/Formula/caver-java.rb
+++ b/Formula/caver-java.rb
@@ -4,7 +4,7 @@ class CaverJava < Formula
   url "https://github.com/klaytn/caver-java/releases/download/v1.3.1/caver-java.zip"
 
   sha256 "7993fb566c69fc530e0c4090bfd807293b4823fd94347e88f2d3d1ff3353ff70"
-  depends_on :java => "openjdk@8"
+  depends_on "openjdk@8"
 
   def install
     prefix.install "lib"


### PR DESCRIPTION
- bump 1.8 to openjdk@8

## Proposed changes

- Homebrew formula `depends_on :java =>` will not support `1.8` because of Oracle JDK license issue.
- change depends of Java to OpenJDK@8 which is same as Oracle JDK 1.8

## Types of changes
- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/homebrew-klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/homebrew-klaytn)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- #5 

## Further comments

Please maintain this homebrew formula.